### PR TITLE
Make output directory in function call match 

### DIFF
--- a/R/snodas.R
+++ b/R/snodas.R
@@ -28,7 +28,7 @@ GetSnodasDepthSweDate <- function(datePOSIXct, outputDir='.', overwrite=FALSE,
                                   parallel=(foreach::getDoParWorkers()>1) ){
   
   ## This atomic function gets called below. 
-  GetSnodasDepthSweDate.atomic <- function(datePOSIXct, outputDir='.', overwrite=FALSE, 
+  GetSnodasDepthSweDate.atomic <- function(datePOSIXct, outputDir=outputDir, overwrite=FALSE, 
                                            quiet=TRUE) {
     # date parameters
     yy <- format(datePOSIXct, c("%Y")); mm <- format(datePOSIXct, c("%m"))


### PR DESCRIPTION
I was attempting to iterate through a bunch of dates using this function and kept getting errors related to the function trying to change the working directory after each iteration. Changed this one option so that the output directory in the function options matched what was being done in the function and that fixed the problem.